### PR TITLE
Create _counter tag if sample is cumulative

### DIFF
--- a/ceilometer_publisher_vaultaire/vaultaire.py
+++ b/ceilometer_publisher_vaultaire/vaultaire.py
@@ -152,7 +152,7 @@ class VaultairePublisher(publisher.PublisherBase):
 
                 # If it's a cumulative value, we need to tell vaultaire
                 if sourcedict["type"] == "cumulative":
-                    sourcedict["_counter"] == 1
+                    sourcedict["_counter"] = 1
 
                 # Cast Identifier sections with unique names, in case of metadata overlap
                 sourcedict["counter_name"] = sourcedict.pop("name")

--- a/ceilometer_publisher_vaultaire/vaultaire.py
+++ b/ceilometer_publisher_vaultaire/vaultaire.py
@@ -150,6 +150,10 @@ class VaultairePublisher(publisher.PublisherBase):
                 # Cast unit as a special metadata type
                 sourcedict["_unit"] = sourcedict.pop("unit")
 
+                # If it's a cumulative value, we need to tell vaultaire
+                if sourcedict["type"] == "cumulative":
+                    sourcedict["_counter"] == 1
+
                 # Cast Identifier sections with unique names, in case of metadata overlap
                 sourcedict["counter_name"] = sourcedict.pop("name")
                 sourcedict["counter_type"] = sourcedict.pop("type")


### PR DESCRIPTION
Keeps the counter_type key in the final sourcedict, but creates a vaultaire-specific tag for metadata.
