### PR TITLE
Added event_type to primary identifier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 env:
-  - 'UBUNTU_RELEASE=trusty'
+  - 'UBUNTU_RELEASE=trusty CPATH=/usr/lib/x86_64-linux-gnu/glib-2.0/include:/usr/include/glib-2.0/:/usr/include'
 
 python:
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - sudo su -c "echo '/usr/local/lib' > /etc/ld.so.conf.d/local.conf"
   - sudo ldconfig
   - cd -
+  - sudo ln -sv /usr/include/glib-2.0 /usr/include/glib
 
 script:
   - sudo python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ install:
   - cd -
 
 script:
-  - sudo python setup.py install
+  - sudo python setup.py install -I/usr/include/glib-2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install:
   - sudo su -c "echo '/usr/local/lib' > /etc/ld.so.conf.d/local.conf"
   - sudo ldconfig
   - cd -
-  - sudo ln -sv /usr/include/glib-2.0 /usr/include/glib
 
 script:
-  - sudo python setup.py install
+  - sudo python setup.py install build_ext -I/usr/include/glib-2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ install:
   - cd -
 
 script:
-  - sudo python setup.py install -I/usr/include/glib-2.0
+  - sudo python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ ${UBUNTU_RELEASE} main universe"
   - sudo apt-get update
   - sudo apt-get install python-ceilometer
+  - sudo apt-get install libglib2.0-dev
   - git clone https://github.com/anchor/libmarquise.git ../libmarquise/
   - cd ../libmarquise/
   - autoreconf -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install python-ceilometer
   - sudo apt-get install libglib2.0-dev
+  - sudo ldconfig
   - git clone https://github.com/anchor/libmarquise.git ../libmarquise/
   - cd ../libmarquise/
   - autoreconf -i

--- a/ceilometer_publisher_vaultaire/vaultaire.py
+++ b/ceilometer_publisher_vaultaire/vaultaire.py
@@ -141,7 +141,7 @@ class VaultairePublisher(publisher.PublisherBase):
                 ## Instance related things
                 flavor_type = ""
                 ### If the flavor key is present, the value of instance_type is really instance_type_id
-                if "flavor" insample:
+                if "flavor" in sample:
                     flavor_type = sample["flavor"].get("name", "")
                 elif "instance_type" in sample:
                     flavor_type = sample["instance_type"]

--- a/ceilometer_publisher_vaultaire/vaultaire.py
+++ b/ceilometer_publisher_vaultaire/vaultaire.py
@@ -129,9 +129,14 @@ class VaultairePublisher(publisher.PublisherBase):
                 sample = sample.as_dict()
                 # Generate the unique identifer for the sample
                 event_type = sample["resource_metadata"].get("event_type", "")
+                flavor_type = ""
+                if "instance_type" in sample:
+                    flavor_type = sample["instance_type"]
+                elif "flavor" in sample:
+                    flavor_type = sample["flavor"].get("name", "")
                 identifier = sample["resource_id"] + sample["project_id"] + \
                              sample["name"] + sample["type"] + sample["unit"] + \
-                             event_type
+                             event_type + flavor_type
                 address = Marquise.hash_identifier(identifier)
 
                 # Sanitize timestamp (will parse timestamp to nanoseconds since epoch)

--- a/ceilometer_publisher_vaultaire/vaultaire.py
+++ b/ceilometer_publisher_vaultaire/vaultaire.py
@@ -127,10 +127,11 @@ class VaultairePublisher(publisher.PublisherBase):
             marq = self.marquise
             for sample in samples:
                 sample = sample.as_dict()
-
                 # Generate the unique identifer for the sample
+                event_type = sample["resource_metadata"].get("event_type", "")
                 identifier = sample["resource_id"] + sample["project_id"] + \
-                             sample["name"] + sample["type"] + sample["unit"]
+                             sample["name"] + sample["type"] + sample["unit"] + \
+                             event_type
                 address = Marquise.hash_identifier(identifier)
 
                 # Sanitize timestamp (will parse timestamp to nanoseconds since epoch)

--- a/ceilometer_publisher_vaultaire/vaultaire.py
+++ b/ceilometer_publisher_vaultaire/vaultaire.py
@@ -132,6 +132,12 @@ class VaultairePublisher(publisher.PublisherBase):
                 cpu_number = sample.get("cpu_number", "")
                 ## Events
                 event_type = sample["resource_metadata"].get("event_type", "")
+                ### If this is event data we care about timestamp + message (Success/Failure)
+                timestamp = ""
+                message = ""
+                if event_type != "":
+                    timestamp = sample["timestamp"]
+                    message = sample["resource_metadata"].get("message", "")
                 ## Instance related things
                 flavor_type = ""
                 ### If the flavor key is present, the value of instance_type is really instance_type_id
@@ -142,7 +148,7 @@ class VaultairePublisher(publisher.PublisherBase):
                 ## Common = r_id + p_id + counter_(name, type, unit)
                 identifier = sample["resource_id"] + sample["project_id"] + \
                              sample["name"] + sample["type"] + sample["unit"] + \
-                             event_type + flavor_type + cpu_number
+                             event_type + flavor_type + cpu_number + message + timestamp
                 address = Marquise.hash_identifier(identifier)
 
                 # Sanitize timestamp (will parse timestamp to nanoseconds since epoch)

--- a/ceilometer_publisher_vaultaire/vaultaire.py
+++ b/ceilometer_publisher_vaultaire/vaultaire.py
@@ -128,15 +128,21 @@ class VaultairePublisher(publisher.PublisherBase):
             for sample in samples:
                 sample = sample.as_dict()
                 # Generate the unique identifer for the sample
+                ## CPU
+                cpu_number = sample.get("cpu_number", "")
+                ## Events
                 event_type = sample["resource_metadata"].get("event_type", "")
+                ## Instance related things
                 flavor_type = ""
-                if "instance_type" in sample:
-                    flavor_type = sample["instance_type"]
-                elif "flavor" in sample:
+                ### If the flavor key is present, the value of instance_type is really instance_type_id
+                if "flavor" insample:
                     flavor_type = sample["flavor"].get("name", "")
+                elif "instance_type" in sample:
+                    flavor_type = sample["instance_type"]
+                ## Common = r_id + p_id + counter_(name, type, unit)
                 identifier = sample["resource_id"] + sample["project_id"] + \
                              sample["name"] + sample["type"] + sample["unit"] + \
-                             event_type + flavor_type
+                             event_type + flavor_type + cpu_number
                 address = Marquise.hash_identifier(identifier)
 
                 # Sanitize timestamp (will parse timestamp to nanoseconds since epoch)


### PR DESCRIPTION
Events are in form $counter_name.[update|create|delete].[start|end]
It is possible for the other components of the current primary identifier to be identical to another but have a different event_type.
The change is required to be able to distinguish between start and end events.
