### PR TITLE
Rename counter_{name,type} to metric_{name,type}

### DIFF
--- a/ceilometer_publisher_vaultaire/process.py
+++ b/ceilometer_publisher_vaultaire/process.py
@@ -86,10 +86,8 @@ def process_raw(sample):
     if event_type is not None:
         sourcedict["event_type"] = event_type
 
-    # XXX: why do we call these counter_* even when they're
-    # not counters?
-    sourcedict["counter_name"] = sanitize(sourcedict.pop("name"))
-    sourcedict["counter_type"] = sanitize(sourcedict.pop("type"))
+    sourcedict["metric_name"] = sanitize(sourcedict.pop("name"))
+    sourcedict["metric_type"] = sanitize(sourcedict.pop("type"))
 
     remove_extraneous(sourcedict)
 


### PR DESCRIPTION
They're not all counters so metric_ seems to make more sense to me; may
as well do it here with all the other breaking changes.
